### PR TITLE
PR06 - Team Claim API

### DIFF
--- a/app/api/leagues/[id]/claim/route.ts
+++ b/app/api/leagues/[id]/claim/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { db } from '@/lib/database';
+import { getSessionUser } from '@/lib/auth';
+import { Prisma } from '@prisma/client';
+
+export const runtime = 'nodejs';
+
+const ClaimTeamSchema = z.object({
+  espnTeamId: z.number().int().min(1)
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Get authenticated user
+    const user = await getSessionUser();
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    // Parse and validate request body
+    const body = await req.json().catch(() => ({}));
+    const { espnTeamId } = ClaimTeamSchema.parse(body);
+
+    const leagueId = params.id;
+
+    // Verify league exists
+    const league = await db.league.findUnique({
+      where: { id: leagueId }
+    });
+
+    if (!league) {
+      return NextResponse.json(
+        { error: 'League not found' },
+        { status: 404 }
+      );
+    }
+
+    // Find the team in this league
+    const team = await db.team.findUnique({
+      where: {
+        leagueId_espnTeamId: {
+          leagueId,
+          espnTeamId
+        }
+      }
+    });
+
+    if (!team) {
+      return NextResponse.json(
+        { error: 'Team not found in this league' },
+        { status: 404 }
+      );
+    }
+
+    try {
+      // Attempt to create the team claim with unique constraints
+      const teamClaim = await db.teamClaim.create({
+        data: {
+          leagueId,
+          teamId: team.id,
+          userId: user.id
+        }
+      });
+
+      return NextResponse.json({
+        ok: true,
+        teamId: team.id,
+        espnTeamId: team.espnTeamId,
+        teamName: team.name,
+        claimedAt: teamClaim.claimedAt
+      });
+
+    } catch (error) {
+      // Handle unique constraint violations
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2002') {
+          const target = error.meta?.target as string[] | undefined;
+          
+          if (target?.includes('leagueId') && target?.includes('teamId')) {
+            // Team already claimed by someone else
+            return NextResponse.json(
+              { error: 'Team already claimed by another user' },
+              { status: 409 }
+            );
+          }
+          
+          if (target?.includes('leagueId') && target?.includes('userId')) {
+            // User already claimed a team in this league
+            const existingClaim = await db.teamClaim.findUnique({
+              where: {
+                leagueId_userId: {
+                  leagueId,
+                  userId: user.id
+                }
+              },
+              include: {
+                team: true
+              }
+            });
+
+            return NextResponse.json(
+              { 
+                error: 'You have already claimed a team in this league',
+                existingTeam: existingClaim ? {
+                  teamId: existingClaim.team.id,
+                  espnTeamId: existingClaim.team.espnTeamId,
+                  teamName: existingClaim.team.name
+                } : null
+              },
+              { status: 409 }
+            );
+          }
+        }
+      }
+      
+      // Re-throw other errors
+      throw error;
+    }
+
+  } catch (error) {
+    console.error('Team claim error:', error);
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Invalid request data', details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Get current team claim for authenticated user in this league
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Get authenticated user
+    const user = await getSessionUser();
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const leagueId = params.id;
+
+    // Find user's current claim in this league
+    const teamClaim = await db.teamClaim.findUnique({
+      where: {
+        leagueId_userId: {
+          leagueId,
+          userId: user.id
+        }
+      },
+      include: {
+        team: true
+      }
+    });
+
+    if (!teamClaim) {
+      return NextResponse.json(
+        { claimed: false },
+        { status: 200 }
+      );
+    }
+
+    return NextResponse.json({
+      claimed: true,
+      teamId: teamClaim.team.id,
+      espnTeamId: teamClaim.team.espnTeamId,
+      teamName: teamClaim.team.name,
+      claimedAt: teamClaim.claimedAt
+    });
+
+  } catch (error) {
+    console.error('Get team claim error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Release/unclaim current team for authenticated user in this league
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Get authenticated user
+    const user = await getSessionUser();
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const leagueId = params.id;
+
+    // Delete the team claim (if exists)
+    const deletedClaim = await db.teamClaim.deleteMany({
+      where: {
+        leagueId,
+        userId: user.id
+      }
+    });
+
+    if (deletedClaim.count === 0) {
+      return NextResponse.json(
+        { error: 'No team claim found to release' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      message: 'Team claim released successfully'
+    });
+
+  } catch (error) {
+    console.error('Release team claim error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/tests/unit/team-claim-api.spec.ts
+++ b/tests/unit/team-claim-api.spec.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST, GET, DELETE } from '@/app/api/leagues/[id]/claim/route';
+import { Prisma } from '@prisma/client';
+
+// Mock dependencies
+vi.mock('@/lib/database', () => ({
+  db: {
+    league: {
+      findUnique: vi.fn()
+    },
+    team: {
+      findUnique: vi.fn()
+    },
+    teamClaim: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      deleteMany: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getSessionUser: vi.fn()
+}));
+
+describe('Team Claim API', async () => {
+  const mockDb = vi.mocked(await import('@/lib/database')).db;
+  const mockAuth = vi.mocked(await import('@/lib/auth'));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Default auth mock
+    mockAuth.getSessionUser.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com'
+    });
+
+    // Default league mock
+    mockDb.league.findUnique.mockResolvedValue({
+      id: 'league-1',
+      espnLeagueId: '12345',
+      name: 'Test League',
+      season: 2025,
+      scoringJson: {},
+      rosterRulesJson: {},
+      auctionBudget: 200,
+      firstLoadedAt: new Date(),
+      createdBy: null,
+      teams: []
+    });
+
+    // Default team mock
+    mockDb.team.findUnique.mockResolvedValue({
+      id: 'team-1',
+      leagueId: 'league-1',
+      espnTeamId: 3,
+      name: 'Team Alpha',
+      ownerUserId: null
+    });
+  });
+
+  const createRequest = (body: any) => {
+    return new NextRequest('http://localhost:3000/api/leagues/league-1/claim', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  };
+
+  const createGetRequest = () => {
+    return new NextRequest('http://localhost:3000/api/leagues/league-1/claim', {
+      method: 'GET'
+    });
+  };
+
+  const createDeleteRequest = () => {
+    return new NextRequest('http://localhost:3000/api/leagues/league-1/claim', {
+      method: 'DELETE'
+    });
+  };
+
+  describe('POST /api/leagues/[id]/claim', () => {
+    it('successfully claims an available team', async () => {
+      mockDb.teamClaim.create.mockResolvedValue({
+        id: 'claim-1',
+        leagueId: 'league-1',
+        teamId: 'team-1',
+        userId: 'user-1',
+        claimedAt: new Date('2025-01-01T00:00:00Z'),
+        team: {
+          id: 'team-1',
+          name: 'Team Alpha',
+          espnTeamId: 3
+        }
+      });
+
+      const request = createRequest({ espnTeamId: 3 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        ok: true,
+        teamId: 'team-1',
+        espnTeamId: 3,
+        teamName: 'Team Alpha',
+        claimedAt: '2025-01-01T00:00:00.000Z'
+      });
+
+      expect(mockDb.teamClaim.create).toHaveBeenCalledWith({
+        data: {
+          leagueId: 'league-1',
+          teamId: 'team-1',
+          userId: 'user-1'
+        }
+      });
+    });
+
+    it('returns 401 when user not authenticated', async () => {
+      mockAuth.getSessionUser.mockResolvedValue(null);
+
+      const request = createRequest({ espnTeamId: 3 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Authentication required');
+    });
+
+    it('returns 404 when league not found', async () => {
+      mockDb.league.findUnique.mockResolvedValue(null);
+
+      const request = createRequest({ espnTeamId: 3 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe('League not found');
+    });
+
+    it('returns 404 when team not found', async () => {
+      mockDb.team.findUnique.mockResolvedValue(null);
+
+      const request = createRequest({ espnTeamId: 999 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe('Team not found in this league');
+    });
+
+    it('returns 409 when team already claimed by another user', async () => {
+      // Mock unique constraint violation for team already claimed
+      const prismaError = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+          meta: {
+            target: ['leagueId', 'teamId']
+          }
+        }
+      );
+
+      mockDb.teamClaim.create.mockRejectedValue(prismaError);
+
+      const request = createRequest({ espnTeamId: 3 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error).toBe('Team already claimed by another user');
+    });
+
+    it('returns 409 when user already claimed a team in this league', async () => {
+      // Mock unique constraint violation for user already has claim
+      const prismaError = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+          meta: {
+            target: ['leagueId', 'userId']
+          }
+        }
+      );
+
+      mockDb.teamClaim.create.mockRejectedValue(prismaError);
+
+      // Mock existing claim lookup
+      mockDb.teamClaim.findUnique.mockResolvedValue({
+        id: 'existing-claim',
+        leagueId: 'league-1',
+        teamId: 'team-2',
+        userId: 'user-1',
+        claimedAt: new Date(),
+        team: {
+          id: 'team-2',
+          leagueId: 'league-1',
+          espnTeamId: 5,
+          name: 'Team Beta',
+          ownerUserId: null
+        }
+      });
+
+      const request = createRequest({ espnTeamId: 3 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error).toBe('You have already claimed a team in this league');
+      expect(data.existingTeam).toEqual({
+        teamId: 'team-2',
+        espnTeamId: 5,
+        teamName: 'Team Beta'
+      });
+    });
+
+    it('validates request body', async () => {
+      const request = createRequest({ espnTeamId: 'invalid' });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Invalid request data');
+      expect(data.details).toBeDefined();
+    });
+
+    it('handles malformed JSON', async () => {
+      const request = new NextRequest('http://localhost:3000/api/leagues/league-1/claim', {
+        method: 'POST',
+        body: 'invalid json',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Invalid request data');
+    });
+  });
+
+  describe('GET /api/leagues/[id]/claim', () => {
+    it('returns current team claim', async () => {
+      mockDb.teamClaim.findUnique.mockResolvedValue({
+        id: 'claim-1',
+        leagueId: 'league-1',
+        teamId: 'team-1',
+        userId: 'user-1',
+        claimedAt: new Date('2025-01-01T00:00:00Z'),
+        team: {
+          id: 'team-1',
+          leagueId: 'league-1',
+          espnTeamId: 3,
+          name: 'Team Alpha',
+          ownerUserId: null
+        }
+      });
+
+      const request = createGetRequest();
+      const params = { id: 'league-1' };
+
+      const response = await GET(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        claimed: true,
+        teamId: 'team-1',
+        espnTeamId: 3,
+        teamName: 'Team Alpha',
+        claimedAt: '2025-01-01T00:00:00.000Z'
+      });
+
+      expect(mockDb.teamClaim.findUnique).toHaveBeenCalledWith({
+        where: {
+          leagueId_userId: {
+            leagueId: 'league-1',
+            userId: 'user-1'
+          }
+        },
+        include: {
+          team: true
+        }
+      });
+    });
+
+    it('returns unclaimed status when no claim exists', async () => {
+      mockDb.teamClaim.findUnique.mockResolvedValue(null);
+
+      const request = createGetRequest();
+      const params = { id: 'league-1' };
+
+      const response = await GET(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        claimed: false
+      });
+    });
+
+    it('returns 401 when user not authenticated', async () => {
+      mockAuth.getSessionUser.mockResolvedValue(null);
+
+      const request = createGetRequest();
+      const params = { id: 'league-1' };
+
+      const response = await GET(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Authentication required');
+    });
+  });
+
+  describe('DELETE /api/leagues/[id]/claim', () => {
+    it('successfully releases team claim', async () => {
+      mockDb.teamClaim.deleteMany.mockResolvedValue({ count: 1 });
+
+      const request = createDeleteRequest();
+      const params = { id: 'league-1' };
+
+      const response = await DELETE(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        ok: true,
+        message: 'Team claim released successfully'
+      });
+
+      expect(mockDb.teamClaim.deleteMany).toHaveBeenCalledWith({
+        where: {
+          leagueId: 'league-1',
+          userId: 'user-1'
+        }
+      });
+    });
+
+    it('returns 404 when no claim exists to release', async () => {
+      mockDb.teamClaim.deleteMany.mockResolvedValue({ count: 0 });
+
+      const request = createDeleteRequest();
+      const params = { id: 'league-1' };
+
+      const response = await DELETE(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe('No team claim found to release');
+    });
+
+    it('returns 401 when user not authenticated', async () => {
+      mockAuth.getSessionUser.mockResolvedValue(null);
+
+      const request = createDeleteRequest();
+      const params = { id: 'league-1' };
+
+      const response = await DELETE(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Authentication required');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles unexpected database errors', async () => {
+      mockDb.teamClaim.create.mockRejectedValue(new Error('Database connection failed'));
+
+      const request = createRequest({ espnTeamId: 3 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe('Internal server error');
+    });
+
+    it('handles unknown Prisma errors', async () => {
+      const prismaError = new Prisma.PrismaClientKnownRequestError(
+        'Unknown constraint',
+        {
+          code: 'P2003',
+          clientVersion: '5.0.0'
+        }
+      );
+
+      mockDb.teamClaim.create.mockRejectedValue(prismaError);
+
+      const request = createRequest({ espnTeamId: 3 });
+      const params = { id: 'league-1' };
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe('Internal server error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the exclusive team claiming system where users can claim exactly one team per league, and each team can only be claimed once. Uses Prisma unique constraints for atomic operations.

## Changes

### API Implementation
- **app/api/leagues/[id]/claim/route.ts**: Complete CRUD API for team claiming
  - `POST`: Claim a team with exclusive constraints
  - `GET`: Check current claim status
  - `DELETE`: Release/unclaim current team

### Key Features

✅ **Exclusive Claiming**: Enforced via Prisma unique constraints
  - One team per user per league: `@@unique([leagueId, userId])`
  - One user per team per league: `@@unique([leagueId, teamId])`

✅ **Atomic Operations**: Database constraints prevent race conditions

✅ **Comprehensive Error Handling**: 
  - Specific error messages for each constraint violation
  - Existing team information included in conflict responses
  - Graceful handling of missing resources

✅ **Full CRUD Operations**:
  - Claim team (POST)
  - Check claim status (GET) 
  - Release claim (DELETE)

## API Specification

### Claim Team
```http
POST /api/leagues/league-123/claim
Content-Type: application/json

{
  "espnTeamId": 3
}
```

**Success Response (200)**:
```json
{
  "ok": true,
  "teamId": "team-abc", 
  "espnTeamId": 3,
  "teamName": "Team Alpha",
  "claimedAt": "2025-01-22T10:30:00Z"
}
```

**Conflict Responses (409)**:
```json
// Team already claimed by another user
{
  "error": "Team already claimed by another user"
}

// User already claimed a team in this league  
{
  "error": "You have already claimed a team in this league",
  "existingTeam": {
    "teamId": "team-xyz",
    "espnTeamId": 5, 
    "teamName": "Team Beta"
  }
}
```

### Check Claim Status
```http
GET /api/leagues/league-123/claim
```

**Responses**:
```json
// User has claimed a team
{
  "claimed": true,
  "teamId": "team-abc",
  "espnTeamId": 3,
  "teamName": "Team Alpha", 
  "claimedAt": "2025-01-22T10:30:00Z"
}

// User has not claimed a team
{
  "claimed": false
}
```

### Release Claim
```http
DELETE /api/leagues/league-123/claim
```

**Success Response (200)**:
```json
{
  "ok": true,
  "message": "Team claim released successfully"  
}
```

## Error Handling

- **401**: Authentication required
- **400**: Invalid request data (Zod validation)
- **404**: League/team not found, or no claim to release
- **409**: Constraint violations (team/user conflicts)
- **500**: Database errors

## Test Plan

✅ **56 total tests passing** (16 new for PR06)

### Unit Test Coverage
- **Successful claiming**: Atomic team claim creation
- **Constraint violations**: Both unique constraint scenarios
- **Status checking**: Claimed vs unclaimed states  
- **Team release**: Successful and failed releases
- **Input validation**: Zod schema enforcement
- **Error handling**: Database failures and edge cases
- **Authentication**: Protected route behavior

### Test Scenarios
- [x] Claim available team successfully
- [x] Prevent double-claiming same team
- [x] Prevent user claiming multiple teams in league
- [x] Return detailed conflict information
- [x] Check claim status (claimed/unclaimed)
- [x] Release team claim successfully 
- [x] Handle missing leagues/teams gracefully
- [x] Validate request parameters
- [x] Require authentication for all operations

## Implementation Details

### Constraint Enforcement
Uses Prisma's unique constraint handling to atomically prevent conflicts:
- Detects `P2002` error codes for constraint violations
- Parses constraint targets to provide specific error messages
- Provides existing team information for user conflicts

### Database Operations
- **Claim**: Single `create` with constraint handling
- **Status**: `findUnique` with team relation
- **Release**: `deleteMany` for safe cleanup

### Security & Validation
- All operations require authentication
- Input validation via Zod schemas
- League/team existence verification
- Proper error logging without sensitive data exposure

🤖 Generated with [Claude Code](https://claude.ai/code)